### PR TITLE
Minor punctuation fixes.

### DIFF
--- a/irqbalance.1
+++ b/irqbalance.1
@@ -51,7 +51,7 @@ Enables log output optimized for systemd-journal.
 
 .TP
 .B -p, --powerthresh=<threshold>
-Set the threshold at which we attempt to move a CPU into powersave mode
+Set the threshold at which we attempt to move a CPU into powersave mode.
 If more than <threshold> CPUs are more than 1 standard deviation below the
 average CPU softirq workload, and no CPUs are more than 1 standard deviation
 above (and have more than 1 IRQ assigned to them), attempt to place 1 CPU in
@@ -62,7 +62,7 @@ in an effort to prevent that CPU from waking up without need.
 .B -i, --banirq=<irqnum>
 Add the specified IRQ to the set of banned IRQs. irqbalance will not affect
 the affinity of any IRQs on the banned list, allowing them to be specified
-manually.  This option is additive and can be specified multiple times. For
+manually.  This option is additive and can be specified multiple times.  For
 example to ban IRQs 43 and 44 from balancing, use the following command line:
 .B irqbalance --banirq=43 --banirq=44
 
@@ -70,7 +70,7 @@ example to ban IRQs 43 and 44 from balancing, use the following command line:
 .B -m, --banmod=<module_name>
 Add the specified module to the set of banned modules, similiar to --banirq.
 irqbalance will not affect the affinity of any IRQs of given modules, allowing
-them to be specified manually. This option is additive and can be specified
+them to be specified manually.  This option is additive and can be specified
 multiple times. For example to ban all IRQs of module foo and module bar from
 balancing, use the following command line:
 .B irqbalance --banmod=foo --banmod=bar
@@ -171,9 +171,9 @@ Possible values to send:
 .TP
 .B stats
 Retrieve assignment tree of IRQs to CPUs, in recursive manner. For each CPU node
-in tree, it's type, number, load and whether the save mode is active are sent. For
+in tree, it's type, number, load and whether the save mode is active are sent.  For
 each assigned IRQ type, it's number, load, number of IRQs since last rebalancing
-and it's class are sent. Refer to types.h file for explanation of defines.
+and it's class are sent.  Refer to types.h file for explanation of defines.
 .TP
 .B setup
 Get the current value of sleep interval, mask of banned CPUs and and list of banned IRQs.


### PR DESCRIPTION
Added a missing full stop, and put two spaces after full stops for consistency, where missing.